### PR TITLE
Remove tsconfig target 'esnext'

### DIFF
--- a/src/nodeDef/factory.ts
+++ b/src/nodeDef/factory.ts
@@ -1,6 +1,6 @@
 import { Factory } from '../common'
-import { NodeDef, NodeDefType, NodeDefProps, NodeDefPropsAdvanced } from './nodeDef'
 import { UUIDs } from '../utils'
+import { NodeDef, NodeDefType, NodeDefProps, NodeDefPropsAdvanced } from './nodeDef'
 
 export type NodeDefFactoryParams = {
   analysis?: boolean
@@ -11,19 +11,19 @@ export type NodeDefFactoryParams = {
   virtual?: boolean
 }
 
-export const NodeDefFactory: Factory<NodeDef<NodeDefType, NodeDefProps>, NodeDefFactoryParams> = {
-  createInstance: (params: NodeDefFactoryParams): NodeDef<NodeDefType, NodeDefProps> => {
-    const defaultProps = {
-      analysis: false,
-      draft: true,
-      nodeDefParent: null,
-      props: {},
-      propsDraft: {},
-      published: false,
-      temporary: true,
-      virtual: false,
-    }
+const defaultProps = {
+  analysis: false,
+  draft: true,
+  nodeDefParent: null,
+  props: {},
+  propsDraft: {},
+  published: false,
+  temporary: true,
+  virtual: false,
+}
 
+export const NodeDefFactory: Factory<NodeDef<NodeDefType>, NodeDefFactoryParams> = {
+  createInstance: (params: NodeDefFactoryParams): NodeDef<NodeDefType> => {
     const { analysis, draft, nodeDefParent, props, propsAdvanced, published, temporary, type, virtual } = {
       ...defaultProps,
       ...params,
@@ -33,7 +33,7 @@ export const NodeDefFactory: Factory<NodeDef<NodeDefType, NodeDefProps>, NodeDef
       analysis,
       draft,
       meta: {
-        h: [...(nodeDefParent?.meta?.h || []), ...(nodeDefParent?.uuid ? [nodeDefParent?.uuid] : [])],
+        h: nodeDefParent ? [...nodeDefParent.meta.h, nodeDefParent.uuid] : [],
       },
       parentUuid: nodeDefParent?.uuid,
       props,

--- a/src/nodeDef/nodeDef.test.ts
+++ b/src/nodeDef/nodeDef.test.ts
@@ -1,43 +1,53 @@
 import { NodeDefFactory, NodeDefFactoryParams } from './factory'
-import { NodeDefType } from './nodeDef'
+import { NodeDef, NodeDefType } from './nodeDef'
 
-describe('NodeDefFactory', () => {
-  test('createInstence - nodeDef', () => {
-    const nodeDefParams: NodeDefFactoryParams = {
-      type: NodeDefType.text,
-      props: {
-        name: 'Name',
-        multiple: false,
-      },
-      analysis: true,
-      virtual: true,
-    }
+const clusterParams: NodeDefFactoryParams = {
+  analysis: false,
+  props: {
+    name: 'cluster',
+    multiple: false,
+  },
+  type: NodeDefType.entity,
+  virtual: false,
+}
+const cluster = NodeDefFactory.createInstance(clusterParams)
 
-    const nodeDef = NodeDefFactory.createInstance(nodeDefParams)
+const dbhParams: NodeDefFactoryParams = {
+  analysis: true,
+  nodeDefParent: cluster,
+  props: {
+    name: 'dbh',
+    multiple: false,
+  },
+  type: NodeDefType.decimal,
+  virtual: false,
+}
+const dbh = NodeDefFactory.createInstance(dbhParams)
+
+const testNodeDef = (nodeDef: NodeDef<any>, params: NodeDefFactoryParams) =>
+  test(`createInstance ${nodeDef.props.name}`, () => {
+    const { analysis, nodeDefParent, props, type, virtual } = params
 
     expect(nodeDef).toHaveProperty('analysis')
-    expect(nodeDef.analysis).toBe(true)
+    expect(nodeDef.analysis).toBe(analysis)
 
     expect(nodeDef).toHaveProperty('draft')
     expect(nodeDef.draft).toBe(true)
 
     expect(nodeDef).toHaveProperty('meta')
     expect(nodeDef.meta).toHaveProperty('h')
-    const expectedHierarchy = [
-      ...(nodeDefParams.nodeDefParent?.meta?.h || []),
-      ...(nodeDefParams.nodeDefParent?.uuid || []),
-    ]
-    expect((nodeDef?.meta?.h || []).length).toBe(expectedHierarchy.length)
-    expect([...(nodeDef?.meta?.h || [])]).toMatchObject(expectedHierarchy)
+    const expectedHierarchy: Array<string> = nodeDefParent ? [...nodeDefParent.meta.h, nodeDefParent.uuid] : []
+    expect(nodeDef.meta.h.length).toBe(expectedHierarchy.length)
+    expect(nodeDef.meta.h).toMatchObject(expectedHierarchy)
 
     expect(nodeDef).toHaveProperty('parentUuid')
-    expect(nodeDef.parentUuid).toBe(nodeDefParams.nodeDefParent?.uuid)
+    expect(nodeDef.parentUuid).toBe(nodeDefParent?.uuid)
 
     expect(nodeDef).toHaveProperty('props')
     expect(nodeDef.props).toHaveProperty('name')
-    expect(nodeDef.props.name).toBe(nodeDefParams.props?.name)
+    expect(nodeDef.props.name).toBe(props?.name)
     expect(nodeDef.props).toHaveProperty('multiple')
-    expect(nodeDef.props.multiple).toBe(nodeDefParams.props?.multiple)
+    expect(nodeDef.props.multiple).toBe(props?.multiple)
 
     expect(nodeDef).toHaveProperty('propsAdvanced')
     expect(nodeDef.propsAdvanced).toBeUndefined()
@@ -49,9 +59,13 @@ describe('NodeDefFactory', () => {
     expect(nodeDef.temporary).toBe(true)
 
     expect(nodeDef).toHaveProperty('type')
-    expect(nodeDef.type).toBe(nodeDefParams.type)
+    expect(nodeDef.type).toBe(type)
 
     expect(nodeDef).toHaveProperty('virtual')
-    expect(nodeDef.virtual).toBe(true)
+    expect(nodeDef.virtual).toBe(virtual)
   })
+
+describe('NodeDefFactory', () => {
+  testNodeDef(cluster, clusterParams)
+  testNodeDef(dbh, dbhParams)
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "isolatedModules": true,
+    "lib": ["DOM", "ESNext"],
     "module": "CommonJS",
     "moduleResolution": "Node",
     "noFallthroughCasesInSwitch": true,
@@ -25,7 +26,6 @@
     "sourceMap": true,
     "strict": true,
     "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    "target": "esnext"
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
## Description

When complining ts project with target 'esnext' some features are not supported by browsers, therefore arena-core cannot be imported in arena client side code.

<!--- List the changes proposed and/or how the issue(s) has(have) been solved. -->

- #### Removed tsconfig target 'esnext'
   
- #### Improved nodeDefFactory test with one entity and one attribute
    

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has this been tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Do you consider this PR needs further testing?

- [X] No
- [ ] Yes

<!--- If Yes, describe why or what to do next -->

## Disclaimer

<!--- Provide a description about anything unusual. -->
