### PR TITLE
Record validation code cleanup

### DIFF
--- a/src/record/recordValidator/attributeTypeValidator.ts
+++ b/src/record/recordValidator/attributeTypeValidator.ts
@@ -111,7 +111,7 @@ const validateValueType =
 
     const typeValidatorFn = typeValidatorFns[nodeDef.type]
     const valid = typeValidatorFn({ survey, nodeDef, node, value: node.value })
-    return ValidationResultFactory.createInstance({ key: 'record.node.valueInvalid', valid })
+    return ValidationResultFactory.createInstance({ key: 'record.attribute.valueInvalid', valid })
   }
 
 export const AttributeTypeValidator = {

--- a/src/record/recordValidator/attributeValidator.ts
+++ b/src/record/recordValidator/attributeValidator.ts
@@ -69,7 +69,7 @@ const _validateRequired =
     return valid
       ? ValidationResultFactory.createInstance()
       : ValidationResultFactory.createInstance({
-          key: 'record.valueRequired',
+          key: 'record.attribute.valueRequired',
           severity: ValidationSeverity.error,
           valid,
         })
@@ -99,7 +99,7 @@ const _validateNodeValidations =
 
     for (const { expression, value: valid } of applicableExpressionsEval) {
       if (!valid) {
-        const customMessages = _getValidationMessagesWithDefault({
+        const messages = _getValidationMessagesWithDefault({
           survey,
           expression,
           defaultMessage: expression.expression,
@@ -109,7 +109,7 @@ const _validateNodeValidations =
           valid: false,
           key: 'record.attribute.customValidation',
           severity: expression.severity,
-          customMessages,
+          messages,
         })
         break
       }

--- a/src/record/recordValidator/countVaildator.ts
+++ b/src/record/recordValidator/countVaildator.ts
@@ -20,7 +20,7 @@ const _createValidationResult = (params: {
       valid: false,
       errors: [
         ValidationResultFactory.createInstance({
-          key: 'record.nodes.countInvalid',
+          key: 'record.nodes.count.invalid',
           params: { nodeDefUuid, count: minCount },
           severity: ValidationSeverity.error,
         }),
@@ -31,7 +31,7 @@ const _createValidationResult = (params: {
     valid: false,
     errors: [
       ValidationResultFactory.createInstance({
-        key: isMinCountValidation ? 'record.nodes.minCountNotReached' : 'record.nodes.maxCountExceeded',
+        key: isMinCountValidation ? 'record.nodes.count.minNotReached' : 'record.nodes.count.maxExceeded',
         params: { nodeDefUuid, ...(isMinCountValidation ? { minCount } : { maxCount }) },
         severity: ValidationSeverity.error,
       }),

--- a/src/record/records.ts
+++ b/src/record/records.ts
@@ -253,12 +253,15 @@ const getDependentNodePointers = (params: {
     })
   }
   if (includeSelf) {
-    const nodePointerSelf = {
-      nodeDef,
-      nodeCtx: node,
-    }
-    if (filterFn === null || filterFn(nodePointerSelf)) {
-      nodePointers.push(nodePointerSelf)
+    const parentNode = Records.getParent({ record, node })
+    if (parentNode) {
+      const nodePointerSelf: NodePointer = {
+        nodeCtx: parentNode,
+        nodeDef,
+      }
+      if (filterFn === null || filterFn(nodePointerSelf)) {
+        nodePointers.push(nodePointerSelf)
+      }
     }
   }
 

--- a/src/validation/factory.ts
+++ b/src/validation/factory.ts
@@ -33,7 +33,7 @@ export const ValidationFactory: Factory<Validation, ValidationFactoryParams> = {
 }
 
 type ValidationResultFactoryParams = {
-  customMessages?: Labels
+  messages?: Labels
   key?: string
   params?: { [key: string]: any }
   severity?: ValidationSeverity
@@ -46,12 +46,12 @@ export const ValidationResultFactory: Factory<ValidationResult, ValidationResult
       valid: true,
     }
 
-    const { severity, key, params: _params, customMessages, valid } = { ...defaultParams, ...params }
+    const { severity, key, params: _params, messages, valid } = { ...defaultParams, ...params }
     return {
       severity,
       key,
       params: _params,
-      customMessages,
+      messages,
       valid,
     }
   },

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -9,7 +9,7 @@ export interface ValidationResult {
   severity?: ValidationSeverity
   key?: string
   params?: { [key: string]: any }
-  customMessages?: Labels
+  messages?: Labels
   valid: boolean
 }
 


### PR DESCRIPTION
should all the validation error keys have a prefix like in arena, something like 'validationError' or 'validation.error.' or similar?!