### PR TITLE
fix: skip missing node defs when evaluating dependencies

### DIFF
--- a/src/survey/surveys/dependencies.ts
+++ b/src/survey/surveys/dependencies.ts
@@ -48,7 +48,7 @@ export const getNodeDefDependents = (params: {
       dependentUuids.add(dependentUuid)
     })
   })
-  return SurveyNodeDefs.getNodeDefsByUuids({ survey, uuids: [...dependentUuids] })
+  return dependentUuids.size > 0 ? SurveyNodeDefs.findNodeDefsByUuids({ survey, uuids: [...dependentUuids] }) : []
 }
 
 const getDependencies = (params: {

--- a/src/survey/surveys/nodeDefs.ts
+++ b/src/survey/surveys/nodeDefs.ts
@@ -13,9 +13,24 @@ export const getNodeDefByName = (params: { survey: Survey; name: string }): Node
   if (!nodeDef) throw new SystemError('survey.nodeDefNameNotFound', { name })
   return nodeDef
 }
+
 export const getNodeDefsByUuids = (params: { survey: Survey; uuids: string[] }) => {
   const { survey, uuids } = params
   return uuids.map((uuid) => getNodeDefByUuid({ survey, uuid }))
+}
+
+export const findNodeDefsByUuids = (params: {
+  survey: Survey
+  uuids: string[]
+}): NodeDef<NodeDefType, NodeDefProps>[] => {
+  const { survey, uuids } = params
+  return uuids.reduce((acc: NodeDef<NodeDefType, NodeDefProps>[], uuid) => {
+    const nodeDef = findNodeDefByUuid({ survey, uuid })
+    if (nodeDef) {
+      acc.push(nodeDef)
+    }
+    return acc
+  }, [])
 }
 
 export const getNodeDefByUuid = (params: { survey: Survey; uuid: string }): NodeDef<NodeDefType, NodeDefProps> => {
@@ -23,6 +38,17 @@ export const getNodeDefByUuid = (params: { survey: Survey; uuid: string }): Node
   const nodeDef = survey.nodeDefs?.[uuid]
   if (!nodeDef) throw new SystemError('survey.nodeDefUuidNotFound', { uuid })
   return nodeDef
+}
+
+export const findNodeDefByUuid = (params: {
+  survey: Survey
+  uuid: string
+}): NodeDef<NodeDefType, NodeDefProps> | undefined => {
+  try {
+    return getNodeDefByUuid(params)
+  } catch (error) {
+    return undefined
+  }
 }
 
 export const getNodeDefParent = (params: {


### PR DESCRIPTION
the dependency graph can be generated and stored in Arena including node defs that are not published yet.
When the survey is fetched with "draft=false", without including published node defs, in the graph there could be references to draft node defs; the core should not throw errors in that case.