### PR TITLE
Fixed expression with $context evaluation on node delete

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,16 +1,16 @@
 queue_rules:
   - name: default
-    conditions:
+    queue_conditions:
       - check-success=build
       - check-success=DeepScan
-      
+    merge_method: squash
+
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
-      - "#approved-reviews-by>=1"
+      - '#approved-reviews-by>=1'
     actions:
       queue:
-        method: squash
         name: default
   - name: automatic branch update
     conditions:

--- a/src/survey/surveys/dependencies.test.ts
+++ b/src/survey/surveys/dependencies.test.ts
@@ -36,10 +36,12 @@ describe('Survey Dependencies', () => {
         entityDef(
           'plot',
           integerDef('plot_id').key(),
-          integerDef('plot_id_double').readOnly().defaultValue('plot_id * 2')
+          integerDef('plot_id_double').readOnly().defaultValue('plot_id * 2'),
+          integerDef('plot_index').readOnly().defaultValue('index($context)').defaultValueEvaluatedOnlyOneTime()
         )
           .multiple()
-          .applyIf('accessible')
+          .applyIf('accessible'),
+        integerDef('plot_count').readOnly().defaultValue('plot.length')
       )
     ).build()
   }, 10000)
@@ -65,6 +67,14 @@ describe('Survey Dependencies', () => {
       sourceName: 'plot_id',
       dependencyType: SurveyDependencyType.defaultValues,
       expectedDependentNames: ['plot_id_double'],
+    })
+  })
+
+  test('Default values dependency ($context)', () => {
+    expectDependents({
+      sourceName: 'plot',
+      dependencyType: SurveyDependencyType.defaultValues,
+      expectedDependentNames: ['plot_index', 'plot_count'],
     })
   })
 

--- a/src/survey/surveys/dependencies.ts
+++ b/src/survey/surveys/dependencies.ts
@@ -8,10 +8,10 @@ import { NodeDefExpressionFactory } from '../../nodeDef/nodeDef'
 
 const isContextParentByDependencyType = {
   [SurveyDependencyType.applicable]: true,
-  [SurveyDependencyType.defaultValues]: false,
+  [SurveyDependencyType.defaultValues]: true,
   [SurveyDependencyType.fileName]: true,
   [SurveyDependencyType.formula]: false,
-  [SurveyDependencyType.validations]: false,
+  [SurveyDependencyType.validations]: true,
 }
 
 const selfReferenceAllowedByDependencyType = {

--- a/src/tests/builder/surveyBuilder/nodeDefAttributeBuilder.ts
+++ b/src/tests/builder/surveyBuilder/nodeDefAttributeBuilder.ts
@@ -41,6 +41,11 @@ export class NodeDefAttributeBuilder extends NodeDefBuilder {
     return this
   }
 
+  defaultValueEvaluatedOnlyOneTime(): this {
+    this.propsAdvanced.defaultValueEvaluatedOneTime = true
+    return this
+  }
+
   validationExpressions(...expressions: (string | NodeDefExpression)[]): this {
     if (!this.propsAdvanced.validations) this.propsAdvanced.validations = {}
     this.propsAdvanced.validations.expressions = expressions.map((expression) =>


### PR DESCRIPTION
when building the survey dependency graph, if $context is used in an expression as identifier, the context node (parent entity) will be included among the referenced node defs.