### PR TITLE
fix: use optional catch binding for unused error params

### DIFF
--- a/src/geo/points/transform.ts
+++ b/src/geo/points/transform.ts
@@ -39,7 +39,7 @@ export const transform = (point: Point, srsCodeTo: string, srsIndex: SRSIndex = 
     const [long, lat] = proj4(srsFrom.wkt, srsTo.wkt, [Number(x), Number(y)])
 
     return PointFactory.createInstance({ ...point, srs: srsCodeTo, x: long, y: lat })
-  } catch (error) {
+  } catch {
     return null
   }
 }

--- a/src/nodeDefExpressionEvaluator/evaluator.ts
+++ b/src/nodeDefExpressionEvaluator/evaluator.ts
@@ -61,7 +61,7 @@ export class NodeDefExpressionEvaluator extends JavascriptExpressionEvaluator<No
     try {
       const { referencedNodeDefUuids } = await this._eval(params)
       return referencedNodeDefUuids
-    } catch (error) {
+    } catch {
       return new Set()
     }
   }

--- a/src/tests/testUtils.ts
+++ b/src/tests/testUtils.ts
@@ -8,7 +8,7 @@ const findNodeDefByName = (params: { survey: Survey; name: string }): NodeDef<an
   const { survey, name } = params
   try {
     return Surveys.getNodeDefByName({ survey, name })
-  } catch (error) {
+  } catch {
     return undefined
   }
 }


### PR DESCRIPTION
Resolves `@typescript-eslint/no-unused-vars` on `catch` clauses in three files; behavior unchanged.

## Description

- Use optional `catch { }` instead of `catch (error)` where the error binding was unused:
  - `src/geo/points/transform.ts`
  - `src/nodeDefExpressionEvaluator/evaluator.ts`
  - `src/tests/testUtils.ts`

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Dependency upgrade

*(Leave “Refactoring” unchecked unless your team treats lint-only fixes as refactoring — many teams tick **Bug fix** for CI/lint fixes.)*

## How has this been tested

- `yarn lint` — passes with no ESLint errors.
- `yarn test` — all suites pass (51 suites, 607 tests).
Environment: local run on branch `fix/eslint-unused-catch-bindings`.

#### Do you consider this PR needs further testing?

- [x] No
- [ ] Yes

## Disclaimer

None — mechanical ESLint-driven change; runtime behavior of the `catch` branches is unchanged.