### PR TITLE
Add data analyst view-not-owned-records security option

### DIFF
--- a/src/auth/authorizer.ts
+++ b/src/auth/authorizer.ts
@@ -73,13 +73,20 @@ export const canViewRecord = _hasSurveyPermission(Permission.recordView)
 export const canExportAllRecords = _hasSurveyPermission(Permission.recordCleanse)
 export const canViewNotOwnedRecords = (user: User, surveyInfo: Survey): boolean => {
   if (!canViewSurvey(user, surveyInfo)) return false
-  if (canExportAllRecords(user, surveyInfo)) return true
+
   const { uuid: surveyUuid } = surveyInfo
   const groupInCurrentSurvey = Users.getAuthGroupBySurveyUuid(surveyUuid)(user)
-  return (
-    groupInCurrentSurvey?.name === AuthGroupName.dataEditor &&
-    Surveys.isDataEditorViewNotOwnedRecordsAllowed(surveyInfo)
-  )
+  const groupName = groupInCurrentSurvey?.name
+
+  if (groupName === AuthGroupName.dataEditor) {
+    return Surveys.isDataEditorViewNotOwnedRecordsAllowed(surveyInfo)
+  }
+  if (groupName === AuthGroupName.dataAnalyst) {
+    return Surveys.isDataAnalystViewNotOwnedRecordsAllowed(surveyInfo)
+  }
+  if (canExportAllRecords(user, surveyInfo)) return true
+
+  return false
 }
 export const canExportRecordsList = _hasSurveyPermission(Permission.surveyEdit)
 

--- a/src/survey/survey.ts
+++ b/src/survey/survey.ts
@@ -39,6 +39,7 @@ export interface SurveyCycle {
 
 export enum SurveySecurityProp {
   dataEditorViewNotOwnedRecordsAllowed = 'dataEditorViewNotOwnedRecordsAllowed',
+  dataAnalystViewNotOwnedRecordsAllowed = 'dataAnalystViewNotOwnedRecordsAllowed',
   visibleInMobile = 'visibleInMobile',
   allowRecordsDownloadInMobile = 'allowRecordsDownloadInMobile',
   allowRecordsUploadFromMobile = 'allowRecordsUploadFromMobile',
@@ -51,6 +52,7 @@ export type SurveySecurity = {
 
 export const surveySecurityDefaults: SurveySecurity = {
   [SurveySecurityProp.dataEditorViewNotOwnedRecordsAllowed]: true,
+  [SurveySecurityProp.dataAnalystViewNotOwnedRecordsAllowed]: true,
   [SurveySecurityProp.visibleInMobile]: true,
   [SurveySecurityProp.allowRecordsDownloadInMobile]: true,
   [SurveySecurityProp.allowRecordsUploadFromMobile]: true,

--- a/src/survey/surveys/index.ts
+++ b/src/survey/surveys/index.ts
@@ -79,6 +79,7 @@ import {
 
 import {
   getSecurity,
+  isDataAnalystViewNotOwnedRecordsAllowed,
   isDataEditorViewNotOwnedRecordsAllowed,
   isRecordsDownloadInMobileAllowed,
   isRecordsUploadFromMobileAllowed,
@@ -168,6 +169,7 @@ export const Surveys = {
 
   // security
   getSecurity,
+  isDataAnalystViewNotOwnedRecordsAllowed,
   isDataEditorViewNotOwnedRecordsAllowed,
   isVisibleInMobile,
   isRecordsDownloadInMobileAllowed,

--- a/src/survey/surveys/surveyGettersSecurity.ts
+++ b/src/survey/surveys/surveyGettersSecurity.ts
@@ -13,6 +13,9 @@ export const isSecurityPropEnabled =
 export const isDataEditorViewNotOwnedRecordsAllowed = (survey: Survey): boolean =>
   isSecurityPropEnabled(SurveySecurityProp.dataEditorViewNotOwnedRecordsAllowed)(survey)
 
+export const isDataAnalystViewNotOwnedRecordsAllowed = (survey: Survey): boolean =>
+  isSecurityPropEnabled(SurveySecurityProp.dataAnalystViewNotOwnedRecordsAllowed)(survey)
+
 export const isVisibleInMobile = (survey: Survey): boolean =>
   isSecurityPropEnabled(SurveySecurityProp.visibleInMobile)(survey)
 


### PR DESCRIPTION
## Summary
- Add `SurveySecurityProp.dataAnalystViewNotOwnedRecordsAllowed` (default: enabled)
- Add `Surveys.isDataAnalystViewNotOwnedRecordsAllowed()`
- Update `canViewNotOwnedRecords()` so data analysts use the survey security toggle instead of the `recordCleanse` bypass

## Test plan
- [x] `yarn test` passes
- [x] `yarn build` succeeds
- [ ] After publish, arena can bump to this version

## Notes
Arena PR depends on this being merged and published to GitHub Packages.