### PR TITLE
feat(records): add pages validation progress API

### DIFF
--- a/src/record/_records/recordPagesValidation.test.ts
+++ b/src/record/_records/recordPagesValidation.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect } from '@jest/globals'
+
+import { NodeDefEntity } from '../../nodeDef'
+import { Records } from '../records'
+import { Surveys } from '../../survey'
+import { SurveyBuilder, SurveyObjectBuilders } from '../../tests/builder/surveyBuilder'
+import { RecordBuilder, RecordNodeBuilders } from '../../tests/builder/recordBuilder'
+import { createTestAdminUser } from '../../tests/data'
+import { Objects, UUIDs } from '../../utils'
+import { ValidationFactory, ValidationResultFactory, ValidationSeverity } from '../../validation'
+
+const { entityDef, integerDef, textDef } = SurveyObjectBuilders
+const { attribute, entity } = RecordNodeBuilders
+
+const cycle = '0'
+
+const setOwnPage = (pageNodeDef: NodeDefEntity, parentNodeDef: NodeDefEntity): void => {
+  const pageUuid = UUIDs.v4()
+  Objects.setInPath({ obj: pageNodeDef, path: ['props', 'layout', cycle, 'pageUuid'], value: pageUuid })
+  const indexChildren =
+    (Objects.path(['props', 'layout', cycle, 'indexChildren'])(parentNodeDef) as string[] | undefined) ?? []
+  Objects.setInPath({
+    obj: parentNodeDef,
+    path: ['props', 'layout', cycle, 'indexChildren'],
+    value: [...indexChildren, pageNodeDef.uuid],
+  })
+}
+
+describe('RecordPagesValidationProgress', () => {
+  test('single root page with no errors is 100% valid', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef('cluster', integerDef('cluster_id').key(), textDef('remarks'))
+    ).build()
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity('cluster', attribute('cluster_id', 10), attribute('remarks', null))
+    ).build()
+
+    expect(Records.getRecordPagesValidationProgress({ survey, record, cycle })).toEqual({
+      percent: 100,
+      validCount: 1,
+      totalCount: 1,
+    })
+  })
+
+  test('own-page error reduces valid page count; nested page errors do not affect parent', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef(
+        'cluster',
+        integerDef('cluster_id').key(),
+        entityDef('plot', integerDef('plot_id').key()).multiple()
+      )
+    ).build()
+
+    const rootDef = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity
+    const plotDef = Surveys.getNodeDefByName({ survey, name: 'plot' }) as NodeDefEntity
+    setOwnPage(plotDef, rootDef)
+
+    expect(Records.getPageNodeDefs({ survey, cycle }).map((d) => d.props.name)).toEqual(['cluster', 'plot'])
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity(
+        'cluster',
+        attribute('cluster_id', 10),
+        entity('plot', attribute('plot_id', 1)),
+        entity('plot', attribute('plot_id', 2))
+      )
+    ).build()
+
+    const clusterIdNode = Records.getNodesByDefUuid(
+      Surveys.getNodeDefByName({ survey, name: 'cluster_id' }).uuid
+    )(record)[0]
+    const plotIdNodes = Records.getNodesByDefUuid(Surveys.getNodeDefByName({ survey, name: 'plot_id' }).uuid)(record)
+
+    // Error only on nested plot field → parent cluster stays valid; 1 of 2 pages invalid.
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [plotIdNodes[0].uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'invalid', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    expect(Records.getRecordPagesValidationProgress({ survey, record, cycle })).toEqual({
+      percent: 50,
+      validCount: 1,
+      totalCount: 2,
+    })
+
+    // Error on root field as well → both pages invalid when nested still has error.
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [clusterIdNode.uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'invalid', severity: ValidationSeverity.error })],
+        }),
+        [plotIdNodes[0].uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'invalid', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    expect(Records.getRecordPagesValidationProgress({ survey, record, cycle })).toEqual({
+      percent: 0,
+      validCount: 0,
+      totalCount: 2,
+    })
+  })
+
+  test('warnings alone do not reduce pages validation progress', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef('cluster', integerDef('cluster_id').key(), textDef('remarks'))
+    ).build()
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity('cluster', attribute('cluster_id', 10), attribute('remarks', 'note'))
+    ).build()
+
+    const remarksNode = Records.getNodesByDefUuid(Surveys.getNodeDefByName({ survey, name: 'remarks' }).uuid)(record)[0]
+    record.validation = ValidationFactory.createInstance({
+      valid: true,
+      fields: {
+        [remarksNode.uuid]: ValidationFactory.createInstance({
+          valid: true,
+          warnings: [ValidationResultFactory.createInstance({ key: 'warn', severity: ValidationSeverity.warning })],
+        }),
+      },
+    })
+
+    expect(Records.getRecordPagesValidationProgress({ survey, record, cycle })).toEqual({
+      percent: 100,
+      validCount: 1,
+      totalCount: 1,
+    })
+
+    expect(
+      Records.getPageValidationStatus({
+        pageNodeDefUuid: Surveys.getNodeDefRoot({ survey }).uuid,
+        record,
+      })
+    ).toEqual({ hasErrors: false, hasWarnings: true })
+  })
+
+  test('getPageValidationStatus scopes to own page when descendant pages are provided', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef(
+        'cluster',
+        integerDef('cluster_id').key(),
+        entityDef('plot', integerDef('plot_id').key()).multiple()
+      )
+    ).build()
+
+    const rootDef = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity
+    const plotDef = Surveys.getNodeDefByName({ survey, name: 'plot' }) as NodeDefEntity
+    setOwnPage(plotDef, rootDef)
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity('cluster', attribute('cluster_id', 10), entity('plot', attribute('plot_id', 1)))
+    ).build()
+
+    const plotIdNode = Records.getNodesByDefUuid(Surveys.getNodeDefByName({ survey, name: 'plot_id' }).uuid)(record)[0]
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [plotIdNode.uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'invalid', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    const descendantPageUuids = Records.getDescendantPageNodeDefUuids({ survey, cycle, pageNodeDef: rootDef })
+    expect(descendantPageUuids).toEqual([plotDef.uuid])
+
+    expect(
+      Records.getPageValidationStatus({
+        pageNodeDefUuid: rootDef.uuid,
+        descendantPageUuids,
+        record,
+      })
+    ).toEqual({ hasErrors: false, hasWarnings: false })
+
+    expect(
+      Records.getPageValidationStatus({
+        pageNodeDefUuid: plotDef.uuid,
+        descendantPageUuids: [],
+        record,
+      })
+    ).toEqual({ hasErrors: true, hasWarnings: false })
+  })
+})

--- a/src/record/_records/recordPagesValidation.test.ts
+++ b/src/record/_records/recordPagesValidation.test.ts
@@ -208,4 +208,134 @@ describe('RecordPagesValidationProgress', () => {
       })
     ).toEqual({ hasErrors: true, hasWarnings: false })
   })
+
+  test('childrenCount validation keys do not affect page validation progress', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef('cluster', integerDef('cluster_id').key(), entityDef('plot', integerDef('plot_id').key()).multiple())
+    ).build()
+
+    const rootDef = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity
+    const plotDef = Surveys.getNodeDefByName({ survey, name: 'plot' }) as NodeDefEntity
+    setOwnPage(plotDef, rootDef)
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity('cluster', attribute('cluster_id', 10), entity('plot', attribute('plot_id', 1)))
+    ).build()
+
+    const clusterNode = Records.getRoot(record)!
+    const childrenCountKey = `childrenCount_${clusterNode.uuid}_${plotDef.uuid}`
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [childrenCountKey]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'record.nodes.count.min', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    expect(Records.getRecordPagesValidationProgress({ survey, record, cycle })).toEqual({
+      percent: 100,
+      validCount: 2,
+      totalCount: 2,
+    })
+  })
+
+  test('three-level own pages: middle page stays valid when only leaf has errors', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef(
+        'cluster',
+        integerDef('cluster_id').key(),
+        entityDef(
+          'plot',
+          integerDef('plot_id').key(),
+          entityDef('tree', integerDef('tree_id').key()).multiple()
+        ).multiple()
+      )
+    ).build()
+
+    const rootDef = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity
+    const plotDef = Surveys.getNodeDefByName({ survey, name: 'plot' }) as NodeDefEntity
+    const treeDef = Surveys.getNodeDefByName({ survey, name: 'tree' }) as NodeDefEntity
+    setOwnPage(plotDef, rootDef)
+    setOwnPage(treeDef, plotDef)
+
+    expect(Records.getPageNodeDefs({ survey, cycle }).map((d) => d.props.name).sort()).toEqual([
+      'cluster',
+      'plot',
+      'tree',
+    ])
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity(
+        'cluster',
+        attribute('cluster_id', 10),
+        entity('plot', attribute('plot_id', 1), entity('tree', attribute('tree_id', 1)))
+      )
+    ).build()
+
+    const treeIdNode = Records.getNodesByDefUuid(Surveys.getNodeDefByName({ survey, name: 'tree_id' }).uuid)(record)[0]
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [treeIdNode.uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'invalid', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    // cluster + plot valid, tree invalid => 2/3
+    expect(Records.getRecordPagesValidationProgress({ survey, record, cycle })).toEqual({
+      percent: 67,
+      validCount: 2,
+      totalCount: 3,
+    })
+  })
+
+  test('nested entity without own page counts toward parent page validation', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef(
+        'cluster',
+        integerDef('cluster_id').key(),
+        entityDef('plot_inline', integerDef('plot_id').key()).multiple()
+      )
+    ).build()
+
+    // plot_inline stays on parent page (no pageUuid)
+    expect(Records.getPageNodeDefs({ survey, cycle }).map((d) => d.props.name)).toEqual(['cluster'])
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity('cluster', attribute('cluster_id', 10), entity('plot_inline', attribute('plot_id', 1)))
+    ).build()
+
+    const plotIdNode = Records.getNodesByDefUuid(Surveys.getNodeDefByName({ survey, name: 'plot_id' }).uuid)(record)[0]
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [plotIdNode.uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'invalid', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    expect(Records.getRecordPagesValidationProgress({ survey, record, cycle })).toEqual({
+      percent: 0,
+      validCount: 0,
+      totalCount: 1,
+    })
+  })
 })

--- a/src/record/_records/recordPagesValidation.ts
+++ b/src/record/_records/recordPagesValidation.ts
@@ -60,7 +60,7 @@ export const getNodeDefChildrenInOwnPage = (params: {
   cycle: string
 }): NodeDefEntity[] => {
   const { survey, nodeDef, cycle } = params
-  return Surveys.getNodeDefChildren({ survey, nodeDef }).filter((child): child is NodeDefEntity => {
+  return Surveys.getNodeDefChildren({ survey, nodeDef, includeAnalysis: true }).filter((child): child is NodeDefEntity => {
     if (!NodeDefs.isEntity(child)) return false
     return NodeDefs.isDisplayInOwnPage(cycle)(child as NodeDefEntity)
   })

--- a/src/record/_records/recordPagesValidation.ts
+++ b/src/record/_records/recordPagesValidation.ts
@@ -29,7 +29,7 @@ export const nodeBelongsToPage = (params: {
   if (node.nodeDefUuid === pageNodeDefUuid) return true
   return Nodes.getHierarchy(node).some((ancestorUuid) => {
     const ancestor = getNodeByUuid(ancestorUuid)(record)
-    return Boolean(ancestor && ancestor.nodeDefUuid === pageNodeDefUuid)
+    return ancestor?.nodeDefUuid === pageNodeDefUuid
   })
 }
 
@@ -106,6 +106,28 @@ export const getDescendantPageNodeDefUuids = (params: {
   return uuids
 }
 
+const getOwnPageFieldValidationFlags = (params: {
+  nodeUuid: string
+  pageNodeDefUuid: string
+  descendantPageUuids: string[]
+  record: Record
+  recordValidation: ReturnType<typeof Validations.getValidation>
+}): PageValidationStatus | null => {
+  const { nodeUuid, pageNodeDefUuid, descendantPageUuids, record, recordValidation } = params
+  if (RecordValidations.isValidationChildrenCountKey(nodeUuid)) return null
+
+  const node = getNodeByUuid(nodeUuid)(record)
+  if (!node || !nodeBelongsToOwnPage({ node, pageNodeDefUuid, descendantPageUuids, record })) return null
+
+  const nodeValidation = RecordValidations.getValidationNode({ nodeUuid })(recordValidation)
+  if (!nodeValidation) return null
+
+  return {
+    hasErrors: Validations.hasErrors(nodeValidation),
+    hasWarnings: Validations.hasWarnings(nodeValidation),
+  }
+}
+
 /**
  * Aggregates error/warning flags for a page.
  * When descendantPageUuids is non-empty, nested page entities are excluded (own-page scope).
@@ -122,14 +144,16 @@ export const getPageValidationStatus = (params: {
   let hasWarnings = false
 
   for (const nodeUuid of Object.keys(fields)) {
-    if (RecordValidations.isValidationChildrenCountKey(nodeUuid)) continue
-    const node = getNodeByUuid(nodeUuid)(record)
-    if (!node) continue
-    if (!nodeBelongsToOwnPage({ node, pageNodeDefUuid, descendantPageUuids, record })) continue
-    const nodeValidation = RecordValidations.getValidationNode({ nodeUuid })(recordValidation)
-    if (!nodeValidation) continue
-    if (Validations.hasErrors(nodeValidation)) hasErrors = true
-    if (Validations.hasWarnings(nodeValidation)) hasWarnings = true
+    const flags = getOwnPageFieldValidationFlags({
+      nodeUuid,
+      pageNodeDefUuid,
+      descendantPageUuids,
+      record,
+      recordValidation,
+    })
+    if (!flags) continue
+    if (flags.hasErrors) hasErrors = true
+    if (flags.hasWarnings) hasWarnings = true
     if (hasErrors && hasWarnings) break
   }
 

--- a/src/record/_records/recordPagesValidation.ts
+++ b/src/record/_records/recordPagesValidation.ts
@@ -1,0 +1,176 @@
+import { Node, Nodes } from '../../node'
+import { NodeDefEntity, NodeDefs } from '../../nodeDef'
+import { Survey, Surveys } from '../../survey'
+import { Validations } from '../../validation'
+import { Record } from '../record'
+import { RecordValidations } from '../recordValidations'
+import { getCycle, getNodeByUuid, getRoot } from './recordGetters'
+
+export type PageValidationStatus = {
+  hasErrors: boolean
+  hasWarnings: boolean
+}
+
+export type PagesValidationProgress = {
+  percent: number
+  validCount: number
+  totalCount: number
+}
+
+/**
+ * Whether a node belongs under a page entity (itself or any descendant of that page).
+ */
+export const nodeBelongsToPage = (params: {
+  node: Node
+  pageNodeDefUuid: string
+  record: Record
+}): boolean => {
+  const { node, pageNodeDefUuid, record } = params
+  if (node.nodeDefUuid === pageNodeDefUuid) return true
+  return Nodes.getHierarchy(node).some((ancestorUuid) => {
+    const ancestor = getNodeByUuid(ancestorUuid)(record)
+    return Boolean(ancestor && ancestor.nodeDefUuid === pageNodeDefUuid)
+  })
+}
+
+/**
+ * Whether a node belongs to this page only — not to a nested descendant page entity.
+ * When descendantPageUuids is empty, all nodes under the page hierarchy are included.
+ */
+export const nodeBelongsToOwnPage = (params: {
+  node: Node
+  pageNodeDefUuid: string
+  descendantPageUuids: string[]
+  record: Record
+}): boolean => {
+  const { node, pageNodeDefUuid, descendantPageUuids, record } = params
+  if (!nodeBelongsToPage({ node, pageNodeDefUuid, record })) return false
+  if (descendantPageUuids.includes(node.nodeDefUuid)) return false
+  return !descendantPageUuids.some((descendantUuid) =>
+    nodeBelongsToPage({ node, pageNodeDefUuid: descendantUuid, record })
+  )
+}
+
+/**
+ * Child page-entity defs displayed in their own page under the given entity.
+ */
+export const getNodeDefChildrenInOwnPage = (params: {
+  survey: Survey
+  nodeDef: NodeDefEntity
+  cycle: string
+}): NodeDefEntity[] => {
+  const { survey, nodeDef, cycle } = params
+  return Surveys.getNodeDefChildren({ survey, nodeDef }).filter((child): child is NodeDefEntity => {
+    if (!NodeDefs.isEntity(child)) return false
+    return NodeDefs.isDisplayInOwnPage(cycle)(child as NodeDefEntity)
+  })
+}
+
+/**
+ * Collects all page-entity node defs in the survey cycle (root + nested own-pages).
+ */
+export const getPageNodeDefs = (params: { survey: Survey; cycle: string }): NodeDefEntity[] => {
+  const { survey, cycle } = params
+  const root = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity | undefined
+  if (!root) return []
+
+  const pages: NodeDefEntity[] = []
+  const stack: NodeDefEntity[] = [root]
+  while (stack.length > 0) {
+    const current = stack.pop()
+    if (!current) continue
+    pages.push(current)
+    stack.push(...getNodeDefChildrenInOwnPage({ survey, nodeDef: current, cycle }))
+  }
+  return pages
+}
+
+/**
+ * Collects descendant page node def UUIDs under a page (not including the page itself).
+ */
+export const getDescendantPageNodeDefUuids = (params: {
+  survey: Survey
+  cycle: string
+  pageNodeDef: NodeDefEntity
+}): string[] => {
+  const { survey, cycle, pageNodeDef } = params
+  const uuids: string[] = []
+  const visit = (nodeDef: NodeDefEntity) => {
+    const children = getNodeDefChildrenInOwnPage({ survey, nodeDef, cycle })
+    for (const child of children) {
+      uuids.push(child.uuid)
+      visit(child)
+    }
+  }
+  visit(pageNodeDef)
+  return uuids
+}
+
+/**
+ * Aggregates error/warning flags for a page.
+ * When descendantPageUuids is non-empty, nested page entities are excluded (own-page scope).
+ */
+export const getPageValidationStatus = (params: {
+  pageNodeDefUuid: string
+  descendantPageUuids?: string[]
+  record: Record
+}): PageValidationStatus => {
+  const { pageNodeDefUuid, descendantPageUuids = [], record } = params
+  const recordValidation = Validations.getValidation(record)
+  const fields = Validations.getFieldValidations(recordValidation)
+  let hasErrors = false
+  let hasWarnings = false
+
+  for (const nodeUuid of Object.keys(fields)) {
+    if (RecordValidations.isValidationChildrenCountKey(nodeUuid)) continue
+    const node = getNodeByUuid(nodeUuid)(record)
+    if (!node) continue
+    if (!nodeBelongsToOwnPage({ node, pageNodeDefUuid, descendantPageUuids, record })) continue
+    const nodeValidation = RecordValidations.getValidationNode({ nodeUuid })(recordValidation)
+    if (!nodeValidation) continue
+    if (Validations.hasErrors(nodeValidation)) hasErrors = true
+    if (Validations.hasWarnings(nodeValidation)) hasWarnings = true
+    if (hasErrors && hasWarnings) break
+  }
+
+  return { hasErrors, hasWarnings }
+}
+
+/**
+ * Whether the page has validation errors on its own fields (excluding nested page entities).
+ */
+export const pageHasOwnErrors = (params: {
+  pageNodeDefUuid: string
+  descendantPageUuids: string[]
+  record: Record
+}): boolean => getPageValidationStatus(params).hasErrors
+
+/**
+ * Progress of pages without own-field validation errors over all survey pages.
+ * Warnings do not reduce the score (matches Arena sidebar red-icon signal).
+ */
+export const getRecordPagesValidationProgress = (params: {
+  survey: Survey
+  record: Record
+  cycle?: string
+}): PagesValidationProgress | null => {
+  const { survey, record } = params
+  if (!getRoot(record)) return null
+
+  const cycle = params.cycle ?? getCycle(record)
+  const pageNodeDefs = getPageNodeDefs({ survey, cycle })
+  const totalCount = pageNodeDefs.length
+  if (totalCount === 0) return null
+
+  let validCount = 0
+  for (const pageNodeDef of pageNodeDefs) {
+    const pageNodeDefUuid = pageNodeDef.uuid
+    const descendantPageUuids = getDescendantPageNodeDefUuids({ survey, cycle, pageNodeDef })
+    if (!pageHasOwnErrors({ pageNodeDefUuid, descendantPageUuids, record })) {
+      validCount += 1
+    }
+  }
+
+  const percent = Math.round((validCount / totalCount) * 100)
+  return { percent, validCount, totalCount }
+}

--- a/src/record/records.ts
+++ b/src/record/records.ts
@@ -46,6 +46,16 @@ import {
   getEntityOwnCompletionPercent,
   getRecordCompletionPercent,
 } from './_records/recordCompletion'
+import {
+  getDescendantPageNodeDefUuids,
+  getNodeDefChildrenInOwnPage,
+  getPageNodeDefs,
+  getPageValidationStatus,
+  getRecordPagesValidationProgress,
+  nodeBelongsToOwnPage,
+  nodeBelongsToPage,
+  pageHasOwnErrors,
+} from './_records/recordPagesValidation'
 import { deleteNode, deleteNodes } from './recordNodesUpdater/recordNodesDeleter'
 
 export const Records = {
@@ -92,6 +102,14 @@ export const Records = {
   getEntityCompletionPercent,
   getEntityOwnCompletionPercent,
   getRecordCompletionPercent,
+  getNodeDefChildrenInOwnPage,
+  getPageNodeDefs,
+  getDescendantPageNodeDefUuids,
+  nodeBelongsToPage,
+  nodeBelongsToOwnPage,
+  getPageValidationStatus,
+  pageHasOwnErrors,
+  getRecordPagesValidationProgress,
   // UPDATE
   addNode,
   addNodes,
@@ -103,3 +121,7 @@ export const Records = {
 }
 
 export type { RecordUpdateOptions } from './_records/recordUpdateOptions'
+export type {
+  PageValidationStatus,
+  PagesValidationProgress,
+} from './_records/recordPagesValidation'


### PR DESCRIPTION
## Summary
- Adds `Records.getRecordPagesValidationProgress({ survey, record, cycle? })` — pages without own-field errors / total pages (warnings ignored).
- Also exports supporting helpers used by Arena sidebar status: `getPageNodeDefs`, `getDescendantPageNodeDefUuids`, `getPageValidationStatus`, `pageHasOwnErrors`, `nodeBelongsToPage` / `nodeBelongsToOwnPage`.
- This is **distinct** from fill-based `getRecordCompletionPercent` (required fields filled).

## Motivation
Arena web shows progress as “valid pages / total pages”. Arena Mobile can reuse the same metric once this lands.

## Test plan
- [x] `yarn test src/record/_records/recordPagesValidation.test.ts`
- [x] `yarn build`
- [ ] Review API naming vs Mobile needs with Stefano