### PR TITLE
fix(records): count attribute childrenCount errors on page status

### DIFF
--- a/src/record/_records/recordPagesValidation.test.ts
+++ b/src/record/_records/recordPagesValidation.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from '@jest/globals'
 
 import { NodeDefEntity } from '../../nodeDef'
 import { Records } from '../records'
+import { RecordValidations } from '../recordValidations'
 import { Surveys } from '../../survey'
 import { SurveyBuilder, SurveyObjectBuilders } from '../../tests/builder/surveyBuilder'
 import { RecordBuilder, RecordNodeBuilders } from '../../tests/builder/recordBuilder'
@@ -9,7 +10,7 @@ import { createTestAdminUser } from '../../tests/data'
 import { Objects, UUIDs } from '../../utils'
 import { ValidationFactory, ValidationResultFactory, ValidationSeverity } from '../../validation'
 
-const { entityDef, integerDef, textDef } = SurveyObjectBuilders
+const { entityDef, fileDef, integerDef, textDef } = SurveyObjectBuilders
 const { attribute, entity } = RecordNodeBuilders
 
 const cycle = '0'
@@ -209,7 +210,7 @@ describe('RecordPagesValidationProgress', () => {
     ).toEqual({ hasErrors: true, hasWarnings: false })
   })
 
-  test('childrenCount validation keys do not affect page validation progress', async () => {
+  test('childrenCount for descendant page entities does not affect parent page validation', async () => {
     const user = createTestAdminUser()
     const survey = await new SurveyBuilder(
       user,
@@ -242,6 +243,55 @@ describe('RecordPagesValidationProgress', () => {
       percent: 100,
       validCount: 2,
       totalCount: 2,
+    })
+  })
+
+  test('childrenCount for file/attribute min count marks the parent page invalid', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef('cluster', integerDef('cluster_id').key(), fileDef('attachment').multiple())
+    ).build()
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity('cluster', attribute('cluster_id', 10))
+    ).build()
+
+    const clusterNode = Records.getRoot(record)!
+    const attachmentDef = Surveys.getNodeDefByName({ survey, name: 'attachment' })
+    const childrenCountKey = RecordValidations.getValidationChildrenCountKey({
+      nodeParentUuid: clusterNode.uuid,
+      nodeDefChildUuid: attachmentDef.uuid,
+    })
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [childrenCountKey]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [
+            ValidationResultFactory.createInstance({
+              key: 'record.nodes.count.minNotReached',
+              severity: ValidationSeverity.error,
+            }),
+          ],
+        }),
+      },
+    })
+
+    expect(
+      Records.getPageValidationStatus({
+        pageNodeDefUuid: Surveys.getNodeDefRoot({ survey }).uuid,
+        descendantPageUuids: [],
+        record,
+      })
+    ).toEqual({ hasErrors: true, hasWarnings: false })
+
+    expect(Records.getRecordPagesValidationProgress({ survey, record, cycle })).toEqual({
+      percent: 0,
+      validCount: 0,
+      totalCount: 1,
     })
   })
 

--- a/src/record/_records/recordPagesValidation.ts
+++ b/src/record/_records/recordPagesValidation.ts
@@ -114,7 +114,16 @@ const getOwnPageFieldValidationFlags = (params: {
   recordValidation: ReturnType<typeof Validations.getValidation>
 }): PageValidationStatus | null => {
   const { nodeUuid, pageNodeDefUuid, descendantPageUuids, record, recordValidation } = params
-  if (RecordValidations.isValidationChildrenCountKey(nodeUuid)) return null
+
+  if (RecordValidations.isValidationChildrenCountKey(nodeUuid)) {
+    return getOwnPageChildrenCountValidationFlags({
+      childrenCountKey: nodeUuid,
+      pageNodeDefUuid,
+      descendantPageUuids,
+      record,
+      recordValidation,
+    })
+  }
 
   const node = getNodeByUuid(nodeUuid)(record)
   if (!node || !nodeBelongsToOwnPage({ node, pageNodeDefUuid, descendantPageUuids, record })) return null
@@ -125,6 +134,41 @@ const getOwnPageFieldValidationFlags = (params: {
   return {
     hasErrors: Validations.hasErrors(nodeValidation),
     hasWarnings: Validations.hasWarnings(nodeValidation),
+  }
+}
+
+/**
+ * Children-count validations (file min count, inline multiple min/max, etc.) are keyed as
+ * `childrenCount_{parentUuid}_{childDefUuid}`, not as node UUIDs.
+ * Include them when the parent is on this page, but skip counts that refer to descendant
+ * page entities (missing sub-page instances should not paint the parent page red).
+ */
+const getOwnPageChildrenCountValidationFlags = (params: {
+  childrenCountKey: string
+  pageNodeDefUuid: string
+  descendantPageUuids: string[]
+  record: Record
+  recordValidation: ReturnType<typeof Validations.getValidation>
+}): PageValidationStatus | null => {
+  const { childrenCountKey, pageNodeDefUuid, descendantPageUuids, record, recordValidation } = params
+  const parentUuid = RecordValidations.extractValidationChildrenCountKeyParentUuid(childrenCountKey)
+  const childDefUuid = RecordValidations.extractValidationChildrenCountKeyNodeDefUuid(childrenCountKey)
+  if (!parentUuid || !childDefUuid) return null
+
+  // Sub-page entity min/max counts belong to navigation of nested pages, not this page's fields.
+  if (descendantPageUuids.includes(childDefUuid)) return null
+
+  const parentNode = getNodeByUuid(parentUuid)(record)
+  if (!parentNode || !nodeBelongsToOwnPage({ node: parentNode, pageNodeDefUuid, descendantPageUuids, record })) {
+    return null
+  }
+
+  const fieldValidation = Validations.getFieldValidation(childrenCountKey)(recordValidation)
+  if (!fieldValidation) return null
+
+  return {
+    hasErrors: Validations.hasErrors(fieldValidation),
+    hasWarnings: Validations.hasWarnings(fieldValidation),
   }
 }
 


### PR DESCRIPTION
## Summary
- Include `childrenCount_*` validations (e.g. mandatory file min count) when aggregating page validation status / pages-valid progress.
- Still ignore children-count keys that refer to descendant **page** entities, so missing sub-page instances do not paint the parent page red.
- Adds coverage for file/attribute min-count errors; keeps the existing descendant-page childrenCount case.

## Test plan
- [x] `yarn test src/record/_records/recordPagesValidation.test.ts`
- [x] In Arena record entry: on a page with a mandatory file, fill other required fields but leave the file empty — sidebar red icon stays and “Invalid record” remains.
- [x] Confirm a parent page with only a missing nested own-page entity min count does not show a red icon from that childrenCount alone.