### PR TITLE
feat(record): entity-scoped page and multiple-entity status APIs

### DIFF
--- a/src/record/_records/recordCompletion.ts
+++ b/src/record/_records/recordCompletion.ts
@@ -71,7 +71,7 @@ const getChildEntityCompletionStats = (params: {
   return stats
 }
 
-const getEntityCompletionStats = (params: {
+export const getEntityCompletionStats = (params: {
   survey: Survey
   record: Record
   entity: Node

--- a/src/record/_records/recordPagesValidation.test.ts
+++ b/src/record/_records/recordPagesValidation.test.ts
@@ -501,6 +501,65 @@ describe('RecordPagesValidationProgress', () => {
     expect(Records.getEntitySubtreeStatus({ survey, record, entityUuid: 'missing-uuid', cycle })).toBeNull()
   })
 
+  test('getEntitySubtreeStatus does not treat vacuous 100% completion as complete', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef(
+        'cluster',
+        integerDef('cluster_id').key(),
+        entityDef('plot', textDef('remarks')).multiple()
+      )
+    ).build()
+
+    const rootDef = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity
+    const plotDef = Surveys.getNodeDefByName({ survey, name: 'plot' }) as NodeDefEntity
+    setOwnPage(plotDef, rootDef)
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity('cluster', attribute('cluster_id', 10), entity('plot', attribute('remarks', null)))
+    ).build()
+
+    const plotEntity = Records.getChildren(
+      Records.getRoot(record)!,
+      plotDef.uuid
+    )(record)[0]
+
+    expect(Records.getEntityCompletionPercent({ survey, record, entity: plotEntity })).toBe(100)
+    expect(Records.getEntityCompletionStats({ survey, record, entity: plotEntity })).toEqual({
+      total: 0,
+      filled: 0,
+    })
+
+    expect(Records.getEntitySubtreeStatus({ survey, record, entityUuid: plotEntity.uuid, cycle })).toEqual({
+      hasErrors: false,
+      hasWarnings: false,
+      isComplete: false,
+    })
+  })
+
+  test('getEntitySubtreeStatus returns null for non-entity nodes', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef('cluster', integerDef('cluster_id').key(), textDef('remarks'))
+    ).build()
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity('cluster', attribute('cluster_id', 10), attribute('remarks', null))
+    ).build()
+
+    const clusterIdNode = Records.getNodesByDefUuid(
+      Surveys.getNodeDefByName({ survey, name: 'cluster_id' }).uuid
+    )(record)[0]
+
+    expect(Records.getEntitySubtreeStatus({ survey, record, entityUuid: clusterIdNode.uuid, cycle })).toBeNull()
+  })
+
   test('getMultiplePageEntitiesStatus ORs errors across instances; complete only if all complete', async () => {
     const user = createTestAdminUser()
     const survey = await new SurveyBuilder(

--- a/src/record/_records/recordPagesValidation.test.ts
+++ b/src/record/_records/recordPagesValidation.test.ts
@@ -642,6 +642,107 @@ describe('RecordPagesValidationProgress', () => {
     })
   })
 
+  test('getMultiplePageEntitiesStatus with scopeEntityUuid ignores nested instances under sibling parents', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef(
+        'cluster',
+        integerDef('cluster_id').key(),
+        entityDef(
+          'plot',
+          integerDef('plot_id').key(),
+          entityDef('tree', integerDef('tree_id').key(), textDef('health').required()).multiple()
+        ).multiple()
+      )
+    ).build()
+
+    const rootDef = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity
+    const plotDef = Surveys.getNodeDefByName({ survey, name: 'plot' }) as NodeDefEntity
+    const treeDef = Surveys.getNodeDefByName({ survey, name: 'tree' }) as NodeDefEntity
+    setOwnPage(plotDef, rootDef)
+    setOwnPage(treeDef, plotDef)
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity(
+        'cluster',
+        attribute('cluster_id', 10),
+        entity(
+          'plot',
+          attribute('plot_id', 3),
+          entity('tree', attribute('tree_id', 1), attribute('health', null))
+        ),
+        entity(
+          'plot',
+          attribute('plot_id', 4),
+          entity('tree', attribute('tree_id', 2), attribute('health', 'ok'))
+        )
+      )
+    ).build()
+
+    const plotIdDefUuid = Surveys.getNodeDefByName({ survey, name: 'plot_id' }).uuid
+    const healthDefUuid = Surveys.getNodeDefByName({ survey, name: 'health' }).uuid
+    const findPlotEntityByPlotId = (plotId: number) => {
+      const plotIdNode = Records.getNodesByDefUuid(plotIdDefUuid)(record).find((n) => n.value === plotId)
+      return Records.getParent(plotIdNode!)(record)!
+    }
+    const plot3 = findPlotEntityByPlotId(3)
+    const plot4 = findPlotEntityByPlotId(4)
+
+    const plot3Tree = Records.getChildren(plot3, treeDef.uuid)(record)[0]
+    const plot3Health = Records.getChildren(plot3Tree, healthDefUuid)(record)[0]
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [plot3Health.uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'required', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    // Unscoped: any tree in the record keeps Tree red.
+    expect(
+      Records.getMultiplePageEntitiesStatus({ survey, record, pageNodeDefUuid: treeDef.uuid, cycle })
+    ).toEqual({
+      hasErrors: true,
+      hasWarnings: false,
+      isComplete: false,
+    })
+
+    // Scoped to Plot 4: only Plot 4's trees — valid.
+    expect(
+      Records.getMultiplePageEntitiesStatus({
+        survey,
+        record,
+        pageNodeDefUuid: treeDef.uuid,
+        cycle,
+        scopeEntityUuid: plot4.uuid,
+      })
+    ).toEqual({
+      hasErrors: false,
+      hasWarnings: false,
+      isComplete: true,
+    })
+
+    // Scoped to Plot 3: only Plot 3's trees — invalid.
+    expect(
+      Records.getMultiplePageEntitiesStatus({
+        survey,
+        record,
+        pageNodeDefUuid: treeDef.uuid,
+        cycle,
+        scopeEntityUuid: plot3.uuid,
+      })
+    ).toEqual({
+      hasErrors: true,
+      hasWarnings: false,
+      isComplete: false,
+    })
+  })
+
   test('nested entity without own page counts toward parent page validation', async () => {
     const user = createTestAdminUser()
     const survey = await new SurveyBuilder(

--- a/src/record/_records/recordPagesValidation.test.ts
+++ b/src/record/_records/recordPagesValidation.test.ts
@@ -351,6 +351,88 @@ describe('RecordPagesValidationProgress', () => {
     })
   })
 
+  test('getPageValidationStatus with scopeEntityUuid ignores sibling entity instances', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef(
+        'cluster',
+        integerDef('cluster_id').key(),
+        entityDef(
+          'plot',
+          integerDef('plot_id').key(),
+          entityDef('land_use', textDef('land_use_code').required())
+        ).multiple()
+      )
+    ).build()
+
+    const rootDef = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity
+    const plotDef = Surveys.getNodeDefByName({ survey, name: 'plot' }) as NodeDefEntity
+    const landUseDef = Surveys.getNodeDefByName({ survey, name: 'land_use' }) as NodeDefEntity
+    setOwnPage(plotDef, rootDef)
+    setOwnPage(landUseDef, plotDef)
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity(
+        'cluster',
+        attribute('cluster_id', 10),
+        entity('plot', attribute('plot_id', 3), entity('land_use', attribute('land_use_code', null))),
+        entity('plot', attribute('plot_id', 4), entity('land_use', attribute('land_use_code', 'crop')))
+      )
+    ).build()
+
+    const landUseCodeDefUuid = Surveys.getNodeDefByName({ survey, name: 'land_use_code' }).uuid
+    const plotIdDefUuid = Surveys.getNodeDefByName({ survey, name: 'plot_id' }).uuid
+    const findPlotEntityByPlotId = (plotId: number) => {
+      const plotIdNode = Records.getNodesByDefUuid(plotIdDefUuid)(record).find((n) => n.value === plotId)
+      return Records.getParent(plotIdNode!)(record)!
+    }
+    const plot3 = findPlotEntityByPlotId(3)
+    const plot4 = findPlotEntityByPlotId(4)
+
+    const plot3LandUse = Records.getChildren(plot3, landUseDef.uuid)(record)[0]
+    const plot3Code = Records.getChildren(plot3LandUse, landUseCodeDefUuid)(record)[0]
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [plot3Code.uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'required', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    const landUseDescendants: string[] = []
+
+    expect(
+      Records.getPageValidationStatus({
+        pageNodeDefUuid: landUseDef.uuid,
+        descendantPageUuids: landUseDescendants,
+        record,
+      })
+    ).toEqual({ hasErrors: true, hasWarnings: false })
+
+    expect(
+      Records.getPageValidationStatus({
+        pageNodeDefUuid: landUseDef.uuid,
+        descendantPageUuids: landUseDescendants,
+        record,
+        scopeEntityUuid: plot3.uuid,
+      })
+    ).toEqual({ hasErrors: true, hasWarnings: false })
+
+    expect(
+      Records.getPageValidationStatus({
+        pageNodeDefUuid: landUseDef.uuid,
+        descendantPageUuids: landUseDescendants,
+        record,
+        scopeEntityUuid: plot4.uuid,
+      })
+    ).toEqual({ hasErrors: false, hasWarnings: false })
+  })
+
   test('nested entity without own page counts toward parent page validation', async () => {
     const user = createTestAdminUser()
     const survey = await new SurveyBuilder(

--- a/src/record/_records/recordPagesValidation.test.ts
+++ b/src/record/_records/recordPagesValidation.test.ts
@@ -433,6 +433,156 @@ describe('RecordPagesValidationProgress', () => {
     ).toEqual({ hasErrors: false, hasWarnings: false })
   })
 
+  test('getEntitySubtreeStatus reflects only that instance subtree', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef(
+        'cluster',
+        integerDef('cluster_id').key(),
+        entityDef(
+          'plot',
+          integerDef('plot_id').key(),
+          entityDef('land_use', textDef('land_use_code').required())
+        ).multiple()
+      )
+    ).build()
+
+    const rootDef = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity
+    const plotDef = Surveys.getNodeDefByName({ survey, name: 'plot' }) as NodeDefEntity
+    const landUseDef = Surveys.getNodeDefByName({ survey, name: 'land_use' }) as NodeDefEntity
+    setOwnPage(plotDef, rootDef)
+    setOwnPage(landUseDef, plotDef)
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity(
+        'cluster',
+        attribute('cluster_id', 10),
+        entity('plot', attribute('plot_id', 3), entity('land_use', attribute('land_use_code', null))),
+        entity('plot', attribute('plot_id', 4), entity('land_use', attribute('land_use_code', 'crop')))
+      )
+    ).build()
+
+    const plotIdDefUuid = Surveys.getNodeDefByName({ survey, name: 'plot_id' }).uuid
+    const landUseCodeDefUuid = Surveys.getNodeDefByName({ survey, name: 'land_use_code' }).uuid
+    const findPlotEntityByPlotId = (plotId: number) => {
+      const plotIdNode = Records.getNodesByDefUuid(plotIdDefUuid)(record).find((n) => n.value === plotId)
+      return Records.getParent(plotIdNode!)(record)!
+    }
+    const plot3 = findPlotEntityByPlotId(3)
+    const plot4 = findPlotEntityByPlotId(4)
+
+    const plot3LandUse = Records.getChildren(plot3, landUseDef.uuid)(record)[0]
+    const plot3Code = Records.getChildren(plot3LandUse, landUseCodeDefUuid)(record)[0]
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [plot3Code.uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'required', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    expect(Records.getEntitySubtreeStatus({ survey, record, entityUuid: plot3.uuid, cycle })).toEqual({
+      hasErrors: true,
+      hasWarnings: false,
+      isComplete: false,
+    })
+
+    expect(Records.getEntitySubtreeStatus({ survey, record, entityUuid: plot4.uuid, cycle })).toEqual({
+      hasErrors: false,
+      hasWarnings: false,
+      isComplete: true,
+    })
+
+    expect(Records.getEntitySubtreeStatus({ survey, record, entityUuid: 'missing-uuid', cycle })).toBeNull()
+  })
+
+  test('getMultiplePageEntitiesStatus ORs errors across instances; complete only if all complete', async () => {
+    const user = createTestAdminUser()
+    const survey = await new SurveyBuilder(
+      user,
+      entityDef(
+        'cluster',
+        integerDef('cluster_id').key(),
+        entityDef(
+          'plot',
+          integerDef('plot_id').key(),
+          entityDef('land_use', textDef('land_use_code').required())
+        ).multiple()
+      )
+    ).build()
+
+    const rootDef = Surveys.getNodeDefRoot({ survey }) as NodeDefEntity
+    const plotDef = Surveys.getNodeDefByName({ survey, name: 'plot' }) as NodeDefEntity
+    const landUseDef = Surveys.getNodeDefByName({ survey, name: 'land_use' }) as NodeDefEntity
+    setOwnPage(plotDef, rootDef)
+    setOwnPage(landUseDef, plotDef)
+
+    const record = new RecordBuilder(
+      user,
+      survey,
+      entity(
+        'cluster',
+        attribute('cluster_id', 10),
+        entity('plot', attribute('plot_id', 3), entity('land_use', attribute('land_use_code', null))),
+        entity('plot', attribute('plot_id', 4), entity('land_use', attribute('land_use_code', 'crop')))
+      )
+    ).build()
+
+    const plotIdDefUuid = Surveys.getNodeDefByName({ survey, name: 'plot_id' }).uuid
+    const landUseCodeDefUuid = Surveys.getNodeDefByName({ survey, name: 'land_use_code' }).uuid
+    const findPlotEntityByPlotId = (plotId: number) => {
+      const plotIdNode = Records.getNodesByDefUuid(plotIdDefUuid)(record).find((n) => n.value === plotId)
+      return Records.getParent(plotIdNode!)(record)!
+    }
+    const plot3 = findPlotEntityByPlotId(3)
+
+    const plot3LandUse = Records.getChildren(plot3, landUseDef.uuid)(record)[0]
+    const plot3Code = Records.getChildren(plot3LandUse, landUseCodeDefUuid)(record)[0]
+    record.validation = ValidationFactory.createInstance({
+      valid: false,
+      fields: {
+        [plot3Code.uuid]: ValidationFactory.createInstance({
+          valid: false,
+          errors: [ValidationResultFactory.createInstance({ key: 'required', severity: ValidationSeverity.error })],
+        }),
+      },
+    })
+
+    expect(Records.getMultiplePageEntitiesStatus({ survey, record, pageNodeDefUuid: plotDef.uuid, cycle })).toEqual({
+      hasErrors: true,
+      hasWarnings: false,
+      isComplete: false,
+    })
+
+    plot3Code.value = 'crop'
+    record.validation = ValidationFactory.createInstance({ valid: true, fields: {} })
+
+    expect(Records.getMultiplePageEntitiesStatus({ survey, record, pageNodeDefUuid: plotDef.uuid, cycle })).toEqual({
+      hasErrors: false,
+      hasWarnings: false,
+      isComplete: true,
+    })
+
+    const emptyRecord = new RecordBuilder(
+      user,
+      survey,
+      entity('cluster', attribute('cluster_id', 10))
+    ).build()
+
+    expect(
+      Records.getMultiplePageEntitiesStatus({ survey, record: emptyRecord, pageNodeDefUuid: plotDef.uuid, cycle })
+    ).toEqual({
+      hasErrors: false,
+      hasWarnings: false,
+      isComplete: false,
+    })
+  })
+
   test('nested entity without own page counts toward parent page validation', async () => {
     const user = createTestAdminUser()
     const survey = await new SurveyBuilder(

--- a/src/record/_records/recordPagesValidation.ts
+++ b/src/record/_records/recordPagesValidation.ts
@@ -106,20 +106,28 @@ export const getDescendantPageNodeDefUuids = (params: {
   return uuids
 }
 
+const nodeIsUnderEntity = (params: { node: Node; entityUuid: string }): boolean => {
+  const { node, entityUuid } = params
+  if (node.uuid === entityUuid) return true
+  return Nodes.getHierarchy(node).includes(entityUuid)
+}
+
 const getOwnPageFieldValidationFlags = (params: {
   nodeUuid: string
   pageNodeDefUuid: string
   descendantPageUuids: string[]
+  scopeEntityUuid?: string
   record: Record
   recordValidation: ReturnType<typeof Validations.getValidation>
 }): PageValidationStatus | null => {
-  const { nodeUuid, pageNodeDefUuid, descendantPageUuids, record, recordValidation } = params
+  const { nodeUuid, pageNodeDefUuid, descendantPageUuids, scopeEntityUuid, record, recordValidation } = params
 
   if (RecordValidations.isValidationChildrenCountKey(nodeUuid)) {
     return getOwnPageChildrenCountValidationFlags({
       childrenCountKey: nodeUuid,
       pageNodeDefUuid,
       descendantPageUuids,
+      scopeEntityUuid,
       record,
       recordValidation,
     })
@@ -127,6 +135,7 @@ const getOwnPageFieldValidationFlags = (params: {
 
   const node = getNodeByUuid(nodeUuid)(record)
   if (!node || !nodeBelongsToOwnPage({ node, pageNodeDefUuid, descendantPageUuids, record })) return null
+  if (scopeEntityUuid && !nodeIsUnderEntity({ node, entityUuid: scopeEntityUuid })) return null
 
   const nodeValidation = RecordValidations.getValidationNode({ nodeUuid })(recordValidation)
   if (!nodeValidation) return null
@@ -147,10 +156,11 @@ const getOwnPageChildrenCountValidationFlags = (params: {
   childrenCountKey: string
   pageNodeDefUuid: string
   descendantPageUuids: string[]
+  scopeEntityUuid?: string
   record: Record
   recordValidation: ReturnType<typeof Validations.getValidation>
 }): PageValidationStatus | null => {
-  const { childrenCountKey, pageNodeDefUuid, descendantPageUuids, record, recordValidation } = params
+  const { childrenCountKey, pageNodeDefUuid, descendantPageUuids, scopeEntityUuid, record, recordValidation } = params
   const parentUuid = RecordValidations.extractValidationChildrenCountKeyParentUuid(childrenCountKey)
   const childDefUuid = RecordValidations.extractValidationChildrenCountKeyNodeDefUuid(childrenCountKey)
   if (!parentUuid || !childDefUuid) return null
@@ -162,6 +172,7 @@ const getOwnPageChildrenCountValidationFlags = (params: {
   if (!parentNode || !nodeBelongsToOwnPage({ node: parentNode, pageNodeDefUuid, descendantPageUuids, record })) {
     return null
   }
+  if (scopeEntityUuid && !nodeIsUnderEntity({ node: parentNode, entityUuid: scopeEntityUuid })) return null
 
   const fieldValidation = Validations.getFieldValidation(childrenCountKey)(recordValidation)
   if (!fieldValidation) return null
@@ -175,13 +186,15 @@ const getOwnPageChildrenCountValidationFlags = (params: {
 /**
  * Aggregates error/warning flags for a page.
  * When descendantPageUuids is non-empty, nested page entities are excluded (own-page scope).
+ * When scopeEntityUuid is set, only validations for nodes under that entity instance are included.
  */
 export const getPageValidationStatus = (params: {
   pageNodeDefUuid: string
   descendantPageUuids?: string[]
   record: Record
+  scopeEntityUuid?: string
 }): PageValidationStatus => {
-  const { pageNodeDefUuid, descendantPageUuids = [], record } = params
+  const { pageNodeDefUuid, descendantPageUuids = [], record, scopeEntityUuid } = params
   const recordValidation = Validations.getValidation(record)
   const fields = Validations.getFieldValidations(recordValidation)
   let hasErrors = false
@@ -192,6 +205,7 @@ export const getPageValidationStatus = (params: {
       nodeUuid,
       pageNodeDefUuid,
       descendantPageUuids,
+      scopeEntityUuid,
       record,
       recordValidation,
     })

--- a/src/record/_records/recordPagesValidation.ts
+++ b/src/record/_records/recordPagesValidation.ts
@@ -4,11 +4,18 @@ import { Survey, Surveys } from '../../survey'
 import { Validations } from '../../validation'
 import { Record } from '../record'
 import { RecordValidations } from '../recordValidations'
-import { getCycle, getNodeByUuid, getRoot } from './recordGetters'
+import { getEntityCompletionPercent } from './recordCompletion'
+import { getCycle, getNodeByUuid, getNodesByDefUuid, getRoot } from './recordGetters'
 
 export type PageValidationStatus = {
   hasErrors: boolean
   hasWarnings: boolean
+}
+
+export type EntitySubtreeStatus = {
+  hasErrors: boolean
+  hasWarnings: boolean
+  isComplete: boolean
 }
 
 export type PagesValidationProgress = {
@@ -216,6 +223,76 @@ export const getPageValidationStatus = (params: {
   }
 
   return { hasErrors, hasWarnings }
+}
+
+const aggregatePageValidationStatuses = (statuses: PageValidationStatus[]): PageValidationStatus => ({
+  hasErrors: statuses.some((status) => status.hasErrors),
+  hasWarnings: statuses.some((status) => status.hasWarnings),
+})
+
+/**
+ * Validation and completion status for one entity instance and its descendant pages.
+ * Returns null when the entity instance is missing from the record.
+ */
+export const getEntitySubtreeStatus = (params: {
+  survey: Survey
+  record: Record
+  entityUuid: string
+  cycle?: string
+}): EntitySubtreeStatus | null => {
+  const { survey, record, entityUuid } = params
+  const entity = getNodeByUuid(entityUuid)(record)
+  if (!entity) return null
+
+  const cycle = params.cycle ?? getCycle(record)
+  const entityPageDef = Surveys.getNodeDefByUuid({ survey, uuid: entity.nodeDefUuid }) as NodeDefEntity
+  const descendantPageUuids = getDescendantPageNodeDefUuids({ survey, cycle, pageNodeDef: entityPageDef })
+  const pageUuidsToCheck = [entity.nodeDefUuid, ...descendantPageUuids]
+
+  const validationStatuses = pageUuidsToCheck.map((pageNodeDefUuid) => {
+    const pageNodeDef = Surveys.getNodeDefByUuid({ survey, uuid: pageNodeDefUuid }) as NodeDefEntity
+    const pageDescendantUuids = getDescendantPageNodeDefUuids({ survey, cycle, pageNodeDef })
+    return getPageValidationStatus({
+      pageNodeDefUuid,
+      descendantPageUuids: pageDescendantUuids,
+      record,
+      scopeEntityUuid: entityUuid,
+    })
+  })
+
+  const { hasErrors, hasWarnings } = aggregatePageValidationStatuses(validationStatuses)
+  const isComplete =
+    getEntityCompletionPercent({ survey, record, entity }) === 100 && !hasErrors && !hasWarnings
+
+  return { hasErrors, hasWarnings, isComplete }
+}
+
+/**
+ * Aggregates subtree status across all instances of a multiple page entity.
+ * Empty instance lists return a non-complete status with no validation flags.
+ */
+export const getMultiplePageEntitiesStatus = (params: {
+  survey: Survey
+  record: Record
+  pageNodeDefUuid: string
+  cycle?: string
+}): EntitySubtreeStatus => {
+  const { survey, record, pageNodeDefUuid } = params
+  const instances = getNodesByDefUuid(pageNodeDefUuid)(record)
+
+  if (instances.length === 0) {
+    return { hasErrors: false, hasWarnings: false, isComplete: false }
+  }
+
+  const instanceStatuses = instances
+    .map((instance) => getEntitySubtreeStatus({ survey, record, entityUuid: instance.uuid, cycle: params.cycle }))
+    .filter((status): status is EntitySubtreeStatus => status !== null)
+
+  return {
+    hasErrors: instanceStatuses.some((status) => status.hasErrors),
+    hasWarnings: instanceStatuses.some((status) => status.hasWarnings),
+    isComplete: instanceStatuses.length > 0 && instanceStatuses.every((status) => status.isComplete),
+  }
 }
 
 /**

--- a/src/record/_records/recordPagesValidation.ts
+++ b/src/record/_records/recordPagesValidation.ts
@@ -4,7 +4,7 @@ import { Survey, Surveys } from '../../survey'
 import { Validations } from '../../validation'
 import { Record } from '../record'
 import { RecordValidations } from '../recordValidations'
-import { getEntityCompletionPercent } from './recordCompletion'
+import { getEntityCompletionStats } from './recordCompletion'
 import { getCycle, getNodeByUuid, getNodesByDefUuid, getRoot } from './recordGetters'
 
 export type PageValidationStatus = {
@@ -232,7 +232,7 @@ const aggregatePageValidationStatuses = (statuses: PageValidationStatus[]): Page
 
 /**
  * Validation and completion status for one entity instance and its descendant pages.
- * Returns null when the entity instance is missing from the record.
+ * Returns null when the node is missing or is not an entity.
  */
 export const getEntitySubtreeStatus = (params: {
   survey: Survey
@@ -244,8 +244,11 @@ export const getEntitySubtreeStatus = (params: {
   const entity = getNodeByUuid(entityUuid)(record)
   if (!entity) return null
 
+  const entityDef = Surveys.getNodeDefByUuid({ survey, uuid: entity.nodeDefUuid })
+  if (!NodeDefs.isEntity(entityDef)) return null
+
   const cycle = params.cycle ?? getCycle(record)
-  const entityPageDef = Surveys.getNodeDefByUuid({ survey, uuid: entity.nodeDefUuid }) as NodeDefEntity
+  const entityPageDef = entityDef as NodeDefEntity
   const descendantPageUuids = getDescendantPageNodeDefUuids({ survey, cycle, pageNodeDef: entityPageDef })
   const pageUuidsToCheck = [entity.nodeDefUuid, ...descendantPageUuids]
 
@@ -261,8 +264,8 @@ export const getEntitySubtreeStatus = (params: {
   })
 
   const { hasErrors, hasWarnings } = aggregatePageValidationStatuses(validationStatuses)
-  const isComplete =
-    getEntityCompletionPercent({ survey, record, entity }) === 100 && !hasErrors && !hasWarnings
+  const { total, filled } = getEntityCompletionStats({ survey, record, entity })
+  const isComplete = total > 0 && filled === total && !hasErrors && !hasWarnings
 
   return { hasErrors, hasWarnings, isComplete }
 }

--- a/src/record/_records/recordPagesValidation.ts
+++ b/src/record/_records/recordPagesValidation.ts
@@ -271,7 +271,9 @@ export const getEntitySubtreeStatus = (params: {
 }
 
 /**
- * Aggregates subtree status across all instances of a multiple page entity.
+ * Aggregates subtree status across instances of a multiple page entity.
+ * When `scopeEntityUuid` is set, only instances under that ancestor entity are included
+ * (needed for nested multiples, e.g. Tree under the currently selected Plot).
  * Empty instance lists return a non-complete status with no validation flags.
  */
 export const getMultiplePageEntitiesStatus = (params: {
@@ -279,9 +281,13 @@ export const getMultiplePageEntitiesStatus = (params: {
   record: Record
   pageNodeDefUuid: string
   cycle?: string
+  /** When set, only instances under this ancestor entity are aggregated. */
+  scopeEntityUuid?: string
 }): EntitySubtreeStatus => {
-  const { survey, record, pageNodeDefUuid } = params
-  const instances = getNodesByDefUuid(pageNodeDefUuid)(record)
+  const { survey, record, pageNodeDefUuid, scopeEntityUuid } = params
+  const instances = getNodesByDefUuid(pageNodeDefUuid)(record).filter((instance) =>
+    scopeEntityUuid ? nodeIsUnderEntity({ node: instance, entityUuid: scopeEntityUuid }) : true
+  )
 
   if (instances.length === 0) {
     return { hasErrors: false, hasWarnings: false, isComplete: false }

--- a/src/record/records.ts
+++ b/src/record/records.ts
@@ -43,6 +43,7 @@ import { addNode, addNodes } from './_records/recordUpdater'
 import { getEnumeratingCategoryItems, findDependentEnumeratedEntityDefsNotEmpty } from './_records/recordUtils'
 import {
   getEntityCompletionPercent,
+  getEntityCompletionStats,
   getEntityOwnCompletionPercent,
   getRecordCompletionPercent,
 } from './_records/recordCompletion'
@@ -102,6 +103,7 @@ export const Records = {
   getStep,
   isInAnalysisStep,
   getEntityCompletionPercent,
+  getEntityCompletionStats,
   getEntityOwnCompletionPercent,
   getRecordCompletionPercent,
   getNodeDefChildrenInOwnPage,

--- a/src/record/records.ts
+++ b/src/record/records.ts
@@ -48,6 +48,8 @@ import {
 } from './_records/recordCompletion'
 import {
   getDescendantPageNodeDefUuids,
+  getEntitySubtreeStatus,
+  getMultiplePageEntitiesStatus,
   getNodeDefChildrenInOwnPage,
   getPageNodeDefs,
   getPageValidationStatus,
@@ -110,6 +112,8 @@ export const Records = {
   getPageValidationStatus,
   pageHasOwnErrors,
   getRecordPagesValidationProgress,
+  getEntitySubtreeStatus,
+  getMultiplePageEntitiesStatus,
   // UPDATE
   addNode,
   addNodes,
@@ -122,6 +126,7 @@ export const Records = {
 
 export type { RecordUpdateOptions } from './_records/recordUpdateOptions'
 export type {
+  EntitySubtreeStatus,
   PageValidationStatus,
   PagesValidationProgress,
 } from './_records/recordPagesValidation'


### PR DESCRIPTION
## Summary
- Add optional `scopeEntityUuid` to `getPageValidationStatus` so sibling multiple-entity instances do not share validation icons.
- Add `getEntitySubtreeStatus` and `getMultiplePageEntitiesStatus` for sidebar/dropdown status (full subtree; complete only when every instance is complete and non-vacuous).
- Scope nested multiples via optional `scopeEntityUuid` on `getMultiplePageEntitiesStatus` (e.g. Trees under the selected Plot only).

## Test plan
- [x] `yarn test` in arena-core (includes `recordPagesValidation.test.ts`)
- [ ] After merge, confirm CI bumps/publishes a new GitHub Packages version (expected `1.4.2`)
- [ ] Bump `@openforis/arena-core` in arena-server and publish server next
- [ ] Smoke-test Arena experimental status icons against the published packages