### PR TITLE
feat(nodeDef): add entity printOrientation prop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,7 @@ export type {
   NodeDefEntityChildPosition,
   NodeDefEntityLayout,
   NodeDefEntityProps,
+  NodeDefPrintOrientation,
   NodeDefFile,
   NodeDefFileProps,
   NodeDefFormHeader,

--- a/src/nodeDef/index.ts
+++ b/src/nodeDef/index.ts
@@ -27,7 +27,13 @@ export type { NodeDefDate } from './types/date'
 
 export type { NodeDefDecimal, NodeDefDecimalProps } from './types/decimal'
 
-export type { NodeDefEntity, NodeDefEntityChildPosition, NodeDefEntityLayout, NodeDefEntityProps } from './types/entity'
+export type {
+  NodeDefEntity,
+  NodeDefEntityChildPosition,
+  NodeDefEntityLayout,
+  NodeDefEntityProps,
+  NodeDefPrintOrientation,
+} from './types/entity'
 
 export { NodeDefEntityRenderType } from './types/entity'
 

--- a/src/nodeDef/nodeDefs.ts
+++ b/src/nodeDef/nodeDefs.ts
@@ -21,6 +21,7 @@ import {
   NodeDefEntityLayout,
   NodeDefEntityLayoutChildItem,
   NodeDefEntityRenderType,
+  NodeDefPrintOrientation,
 } from './types/entity'
 import { NodeDefFile, NodeDefFileType } from './types/file'
 import { NodeDefTaxon } from './types/taxon'
@@ -70,6 +71,9 @@ const isReadOnly = (nodeDef: NodeDef<any>): boolean => nodeDef.props.readOnly ??
 const isHidden = (nodeDef: NodeDef<any>): boolean => nodeDef.props.hidden ?? false
 
 const isEnumerate = (nodeDef: NodeDefEntity): boolean => nodeDef.props.enumerate ?? false
+
+const getPrintOrientation = (nodeDef: NodeDefEntity): NodeDefPrintOrientation | undefined =>
+  nodeDef.props.printOrientation
 
 const getDefaultValues = (nodeDef: NodeDef<NodeDefType>): NodeDefExpression[] =>
   nodeDef.propsAdvanced?.defaultValues ?? []
@@ -271,6 +275,7 @@ export const NodeDefs = {
   isReadOnly,
   isHidden,
   isEnumerate,
+  getPrintOrientation,
   isAnalysis,
   isRoot,
   getType,

--- a/src/nodeDef/types/entity.ts
+++ b/src/nodeDef/types/entity.ts
@@ -12,8 +12,12 @@ export interface NodeDefEntityChildPosition {
 
 export type NodeDefEntityLayoutChildItem = NodeDefEntityChildPosition | string
 
+export type NodeDefPrintOrientation = 'portrait' | 'landscape'
+
 export interface NodeDefEntityProps extends NodeDefPropsWithLayout<NodeDefEntityLayout> {
   enumerate?: boolean
+  /** When set, printable export uses this orientation for the entity's print section. */
+  printOrientation?: NodeDefPrintOrientation
 }
 
 export enum NodeDefEntityRenderType {


### PR DESCRIPTION
## Summary
- Adds optional `printOrientation` (`portrait` | `landscape`) on entity node-def props for printable document sections.
- Exposes `NodeDefs.getPrintOrientation` and exports the new type from the package entrypoints.

## Context
First PR in the record printable-export options work. Consumed by `arena-server` (section orientation) and Arena (designer Print tab).

## Test plan
- [ ] Types compile in arena-core
- [ ] Follow-up arena-server PR can read `entityDef.props.printOrientation`
- [ ] No runtime behavior change without consumers